### PR TITLE
Fix Package installation error #178

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "joblib",
 ]
 
-with open("README.md", "r") as f:
+with open("README.md", mode="r", encoding = "utf8") as f:
     LONG_DESCRIPTION = f.read()
 
 setup(


### PR DESCRIPTION
Initial error: python setup.py install resulted in UnicodeDecodeError: 'charmap' codes can't decode byte 0x9d in position 1558: character maps to <undefined>
Solution: add encoding specification: "utf8"

@jdey4 @sampan501 