### PR TITLE
Modify progressive_learner class to be task-agnostic and subclass into classification_progressive_learner

### DIFF
--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -2,13 +2,13 @@
 Main Author: Will LeVine
 Corresponding Email: levinewill@icloud.com
 '''
-from .progressive_learner import ProgressiveLearner
+from .progressive_learner import ClassificationProgressiveLearner
 from .transformers import TreeClassificationTransformer
 from .voters import TreeClassificationVoter
 from .deciders import SimpleArgmaxAverage
 import numpy as np
 
-class LifelongClassificationForest:
+class LifelongClassificationForest(ClassificationProgressiveLearner):
     """
     A class used to represent a lifelong classification forest.
     
@@ -44,7 +44,7 @@ class LifelongClassificationForest:
         self.n_estimators = n_estimators
         self.default_tree_construction_proportion = default_tree_construction_proportion
         self.default_finite_sample_correction = default_finite_sample_correction
-        self.pl = ProgressiveLearner(
+        self.pl = ClassificationProgressiveLearner(
             default_transformer_class=TreeClassificationTransformer,
             default_transformer_kwargs={},
             default_voter_class=TreeClassificationVoter,

--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -4,7 +4,7 @@ Corresponding Email: levinewill@icloud.com
 '''
 import numpy as np
 
-from .progressive_learner import ProgressiveLearner
+from .progressive_learner import ClassificationProgressiveLearner
 from .transformers import NeuralClassificationTransformer
 from .voters import KNNClassificationVoter
 from .deciders import SimpleArgmaxAverage
@@ -13,7 +13,7 @@ from sklearn.utils import check_X_y, check_array
 from keras.optimizers import Adam
 from keras.callbacks import EarlyStopping
 
-class LifelongClassificationNetwork:
+class LifelongClassificationNetwork(ClassificationProgressiveLearner):
     """
     A class for progressive learning using Lifelong Learning Networks in a classification setting. 
     
@@ -87,7 +87,7 @@ class LifelongClassificationNetwork:
             },
         }
 
-        self.pl = ProgressiveLearner(
+        self.pl = ClassificationProgressiveLearner(
             default_transformer_class=NeuralClassificationTransformer,
             default_transformer_kwargs=default_transformer_kwargs,
             default_voter_class=KNNClassificationVoter,

--- a/proglearn/progressive_learner.py
+++ b/proglearn/progressive_learner.py
@@ -3,11 +3,11 @@ Main Author: Will LeVine
 Corresponding Email: levinewill@icloud.com
 '''
 import numpy as np
-from .base import BaseClassificationDecider, BaseClassificationProgressiveLearner
+from .base import BaseClassificationDecider, BaseClassificationProgressiveLearner, BaseProgressiveLearner
 
-class ProgressiveLearner(BaseClassificationProgressiveLearner):
+class ProgressiveLearner(BaseProgressiveLearner):
     """
-    A class for progressive learning in the classification setting. 
+    A class for progressive learning.
     
     Parameters
     ----------
@@ -661,17 +661,52 @@ class ProgressiveLearner(BaseClassificationProgressiveLearner):
         )
 
     def predict(self, X, task_id, transformer_ids=None):
+        """
+        predicts labels under task_id for each example in input data X
+        using the given transformer_ids.
+        
+        Parameters 
+        ---
+        X : ndarray
+            The input data matrix.
+        task_id : obj
+            The id corresponding to the task being mapped to.
+        transformer_ids : list, default=None
+            The list of transformer_ids through which a user would like 
+            to send X (which will be pipelined with their corresponding 
+            voters) to make an inference prediction.
+        """
         return self.task_id_to_decider[task_id].predict(
             X, transformer_ids=transformer_ids
         )
 
+class ClassificationProgressiveLearner(ProgressiveLearner):
+    '''
+    A class for progressive learning in the classification setting. 
+    
+    Methods
+    ---
+    predict_proba(X, task_id, transformer_ids=None)
+        predicts posteriors under task_id for each example in input data X
+        using the given transformer_ids.
+    '''
     def predict_proba(self, X, task_id, transformer_ids=None):
+        """
+        predicts posteriors under task_id for each example in input data X
+        using the given transformer_ids.
+        
+        Parameters 
+        ---
+        X : ndarray
+            The input data matrix.
+        task_id : obj
+            The id corresponding to the task being mapped to.
+        transformer_ids : list, default=None
+            The list of transformer_ids through which a user would like 
+            to send X (which will be pipelined with their corresponding 
+            voters) to estimate posteriors.
+        """
         decider = self.task_id_to_decider[task_id]
-        if isinstance(decider, BaseClassificationDecider):
-            return self.task_id_to_decider[task_id].predict_proba(
-                X, transformer_ids=transformer_ids
-            )
-        else:
-            raise AttributeError(
-                "Cannot call `predict_proba` on non-classification decider."
-            )
+        return self.task_id_to_decider[task_id].predict_proba(
+            X, transformer_ids=transformer_ids
+        )


### PR DESCRIPTION
**Reference Issues/PRs**
Closing Issue #142 

**What does this implement/fix? Explain your changes.**
Previously, the progressive learner class was narrowly for classification (namely by the inclusion of the predict_proba function, which is not applicable in all settings). As we extend research into regression, it is important to have a progressive learner that is general, and a ClassificationProgressiveLearner that adds the functionality of predict_proba in the classification setting. 