### PR TITLE
Unified name to ProgLearn (I think) everywhere besides the actual repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# progressive-learning
+# ProgLearn
 
 [![Build Status](https://travis-ci.org/neurodata/progressive-learning.svg?branch=master)](https://travis-ci.org/neurodata/progressive-learning)
 [![codecov](https://codecov.io/gh/neurodata/progressive-learning/branch/master/graph/badge.svg)](https://codecov.io/gh/neurodata/progressive-learning)
 [![arXiv shield](https://img.shields.io/badge/arXiv-2004.12908-red.svg?style=flat)](https://arxiv.org/abs/2004.12908)
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
 
-progressive-learning is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
+*Prog*ressive*Learn*ing is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
 
 - [Overview](#overview)
 - [Documentation](#documentation)
@@ -24,7 +24,7 @@ The progressive learning package utilizes representation ensembling algorithms t
 
 # System Requirements
 ## Hardware requirements
-`progressive-learning` package requires only a standard computer with enough RAM to support the in-memory operations. 
+`proglearn` package requires only a standard computer with enough RAM to support the in-memory operations. 
 
 ## Software requirements
 ### OS Requirements
@@ -37,7 +37,7 @@ This package is supported for *Linux* and *macOS*. The package has been tested o
 This package is written for Python3. Currently, it is supported for Python 3.6 and 3.7.
 
 ### Python Dependencies
-`progressive-learning` mainly depends on the Python scientific stack.
+`proglearn` mainly depends on the Python scientific stack.
 ```
 keras
 tensorflow

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![arXiv shield](https://img.shields.io/badge/arXiv-2004.12908-red.svg?style=flat)](https://arxiv.org/abs/2004.12908)
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
 
-*Prog*ressive*Learn*ing is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
+**Prog**ressive**Learn**ing is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
 
 - [Overview](#overview)
 - [Documentation](#documentation)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'ProgL'
-copyright = '2020, Jayanta Dey, Will LeVine'
-author = 'Jayanta Dey, Will LeVine'
+project = 'ProgLearn'
+copyright = '2020, Will LeVine, Jayanta Dey, Hayden Helm'
+author = 'Will LeVine, Jayanta Dey, Hayden Helm'
 
 # The short X.Y version
 version = ''
@@ -103,7 +103,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ProgLdoc'
+htmlhelp_basename = 'ProgLearnDoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -130,8 +130,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ProgL.tex', 'ProgL Documentation',
-     'Jayanta Dey, Will LeVine', 'manual'),
+    (master_doc, 'ProgLearn.tex', 'ProgLearn Documentation',
+     'Will LeVine, Jayanta Dey, Hayden Helm', 'manual'),
 ]
 
 
@@ -140,7 +140,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'progl', 'ProgL Documentation',
+    (master_doc, 'proglearn', 'ProgLearn Documentation',
      [author], 1)
 ]
 
@@ -151,8 +151,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ProgL', 'ProgL Documentation',
-     author, 'ProgL', 'One line description of project.',
+    (master_doc, 'ProgLearn', 'ProgLearn Documentation',
+     author, 'ProgLearn', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,4 @@
-Contributing to Progressive-learning
+Contributing to ProgLearn
 ************************************
 
 (adopted from scikit-learn)
@@ -46,12 +46,12 @@ good feedback:
 - If an exception is raised, please **provide the full traceback**.
 
 - Please include your **operating system type and version number**, as well as
-  your **Python and ProgL versions**. This information
+  your **Python and ProgLearn versions**. This information
   can be found by running the following code snippet::
 
     import platform; print(platform.platform())
     import sys; print("Python", sys.version)
-    import progressive-learning; print("progressive-learning", progressive-learning.__version__)
+    import proglearn; print("ProgLearn", proglearn.__version__)
 
 - Please ensure all **code snippets and error messages are formatted in
   appropriate code blocks**.  See `Creating and highlighting code blocks
@@ -61,7 +61,7 @@ good feedback:
 Contributing Code
 -----------------
 
-The preferred workflow for contributing to `ProgL` is to fork the main
+The preferred workflow for contributing to `ProgLearn` is to fork the main
 repository on GitHub, clone, and develop on a branch. Steps:
 
 1. Fork the `project repository <https://github.com/neurodata/progressive-learning>`__ by clicking
@@ -70,7 +70,7 @@ repository on GitHub, clone, and develop on a branch. Steps:
    fork a repository see `this
    guide <https://help.github.com/articles/fork-a-repo/>`__.
 
-2. Clone your fork of the ``ProgL`` repo from your GitHub account to your
+2. Clone your fork of the ``ProgLearn`` repo from your GitHub account to your
    local disk:
 
    .. code:: bash
@@ -150,7 +150,7 @@ before you submit a pull request:
 Coding Guidelines
 -----------------
 
-Uniformly formatted code makes it easier to share code ownership. ``ProgL``
+Uniformly formatted code makes it easier to share code ownership. ``ProgLearn``
 package closely follows the official Python guidelines detailed in
 `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ that detail how
 code should be formatted and indented. Please read it and follow it.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ProgL's documentation!
+Welcome to ProgLearn's documentation!
 =================================
 
 .. toctree::

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,6 +1,6 @@
 License
 =======
-``Progressive-learning`` is distributed with a Apache 2.0 license.
+``ProgLearn`` is distributed with a Apache 2.0 license.
 
 ::
 


### PR DESCRIPTION
**Reference Issues/PRs**
This is the first step towards #138 

**What does this implement/fix? Explain your changes.**
We previously had mentioned 'progressive-learning', 'progl', and 'proglearn' as the name of our package. This unifies the all mentions of our package (other than the repo URL itself) to 'proglearn'.

**Any other comments?**
This is just the first step of the issue. This does not close the issue. We will still need to change the repo URL (and update Travis/Codecov accordingly) and then upload to PyPi. 