### PR TITLE
Update README to include pip installation instructions and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/neurodata/progressive-learning.svg?branch=master)](https://travis-ci.org/neurodata/progressive-learning)
 [![codecov](https://codecov.io/gh/neurodata/progressive-learning/branch/master/graph/badge.svg)](https://codecov.io/gh/neurodata/progressive-learning)
+[![PyPI version](https://img.shields.io/pypi/v/proglearn.svg)](https://pypi.org/project/proglearn/)
 [![arXiv shield](https://img.shields.io/badge/arXiv-2004.12908-red.svg?style=flat)](https://arxiv.org/abs/2004.12908)
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![arXiv shield](https://img.shields.io/badge/arXiv-2004.12908-red.svg?style=flat)](https://arxiv.org/abs/2004.12908)
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
 
-**Prog**ressive**Learn**ing is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
+`proglearn` (**Prog**ressive **Learn**ing) is a package for exploring and using progressive learning algorithms developed by the [neurodata group](https://neurodata.io).
 
 - [Overview](#overview)
 - [Documentation](#documentation)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ joblib
 # Installation Guide
 ## Install from pip
 ```
-
+pip install proglearn
 ```
 
 ## Install from Github

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,10 @@ with open("README.md", mode="r", encoding = "utf8") as f:
 setup(
     name="proglearn",
     version="0.0.1",
-    author="Will Levine, Jayanta Dey, Hayden Helm",
+    author="Will LeVine, Jayanta Dey, Hayden Helm",
     author_email="levinewill@icloud.com",
+    maintainer="Will LeVine, Jayanta Dey",
+    maintainer_email="levinewill@icloud.com",
     description="A package to implement and extend the methods desribed in 'A General Approach to Progressive Learning'",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,15 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/neurodata/progressive-learning/",
     license="MIT",
-    packages=find_packages(),
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
+    ],
     install_requires=requirements,
+    packages=find_packages(exclude=["tests", "tests.*", "tests/*"]),
+    include_package_data=True
 )


### PR DESCRIPTION
**Reference Issues** 
Issue #138 

**What changes does this address?**
I uploaded to PyPi here: https://pypi.org/project/proglearn/. This PR adds the pip installation command and the PyPi badge to the README

**Any other comments?**
We should very much change the repo URL/name to reflect our package name. 